### PR TITLE
show confirmed bundles in history

### DIFF
--- a/lib/commands/history.js
+++ b/lib/commands/history.js
@@ -44,10 +44,20 @@ const setupHistoryCommand = (data, iotajs, vorpal) => {
       (biggest, bundle) => biggest > bundle[0].value ? biggest : bundle[0].value,
       0
     ) + '';
-
+    const persistences = transfers
+      .reduce(function (a, b) {
+        if (b.persistence && a.indexOf(b.bundle) == -1) {
+          a.push(b.bundle)
+        }
+        return a;
+      }, []);
     transfers.forEach((bundle, index) => {
       const shortAddress = bundle[0].address.slice(0, 6);
       const persisted = bundle[0].persistence ? bundle[0].persistence : false;
+      let reattachConfirmed = false;
+      if (!persisted && persistences.indexOf(bundle[0].bundle)) {
+          reattachConfirmed = true;
+      }
       const shortHash = bundle[0].hash.slice(0, 6);
       const time = moment.unix(bundle[0].timestamp).fromNow();
       const value = bundle[0].value;
@@ -57,7 +67,7 @@ const setupHistoryCommand = (data, iotajs, vorpal) => {
         ? leftPad('address', 13)
         : thisCategorizeTransfer.length > 0 ? 'spending from' : leftPad('receiving to', 13);
 
-      vorpal.log(`${index < 9 ? ' ' : ''}${index+1}: ${chalk.yellow(shortHash)} - ${type} ${shortAddress} - ${leftPad(value, biggestValue.length)} - ${persisted ? chalk.green('confirmed') : chalk.yellow('pending  ')} - ${time}`);
+      vorpal.log(`${index < 9 ? ' ' : ''}${index+1}: ${chalk.yellow(shortHash)} - ${type} ${shortAddress} - ${leftPad(value, biggestValue.length)} - ${persisted ? chalk.green('confirmed        ') : reattachConfirmed ? chalk.cyan('bundle confirmed') : chalk.yellow('pending          ')} - ${time}`);
     });
     vorpal.log(chalk.cyan('\nTo see more information on a specific transaction, provide a hash next time.\n'));
 


### PR DESCRIPTION
If a pending transaction has been confirmed via a reattachment (or a reattachment was confirmed in the original tx) show 'bundle confirmed' in history